### PR TITLE
Upgrade to npm hosted image-size

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "svg"
   ],
   "dependencies": {
-    "image-size": "netroy/image-size#da2c863807a3e9602617bdd357b0de3ab4a064c1",
+    "image-size": "^0.4.0",
     "readable-stream": "^1.0.33",
     "tryit": "^1.0.1"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -80,7 +80,7 @@ describe('imageSizeStream', function() {
         {
           width: 4000,
           height: 6000,
-           type: 'jpg'
+          type: 'jpg'
         }
       ]);
       done();


### PR DESCRIPTION
We had some issues with our `npm-shrinkwrap.json` file because this module used a github url.
By using a npm-hosted module, we get rid of this error.
